### PR TITLE
A variant of startMaster (startMaster') where no slave discovery is made...

### DIFF
--- a/distributed-process-simplelocalnet.cabal
+++ b/distributed-process-simplelocalnet.cabal
@@ -1,5 +1,5 @@
 Name:          distributed-process-simplelocalnet
-Version:       0.2.0.9
+Version:       0.2.0.10
 Cabal-Version: >=1.8
 Build-Type:    Simple
 License:       BSD3 

--- a/src/Control/Distributed/Process/Backend/SimpleLocalnet.hs
+++ b/src/Control/Distributed/Process/Backend/SimpleLocalnet.hs
@@ -92,6 +92,7 @@ module Control.Distributed.Process.Backend.SimpleLocalnet
   , terminateAllSlaves
     -- * Master nodes
   , startMaster
+  , startMaster'
   ) where
 
 import System.IO (fixIO)
@@ -397,6 +398,13 @@ startMaster backend proc = do
     redirectLogsHere backend slaves
     proc (map processNodeId slaves) `finally` shutdownLogger
 
+-- | Works like 'startMaster' but without initially finding slaves in
+-- the local network.
+startMaster' :: Backend -> ([NodeId] -> Process ()) -> IO ()
+startMaster' backend proc = do
+  node <- newLocalNode backend
+  Node.runProcess node $ proc [] `finally` shutdownLogger
+  
 --
 -- | shut down the logger process. This ensures that any pending
 -- messages are flushed before the process exits.


### PR DESCRIPTION
I've added an alternative version of startMaster (called startMaster') where no initial slave discovery is made.

  --patrik
