### PR TITLE
Updated bounds and support for network-3

### DIFF
--- a/distributed-process-simplelocalnet.cabal
+++ b/distributed-process-simplelocalnet.cabal
@@ -42,32 +42,14 @@ Library
   Exposed-modules:   Control.Distributed.Process.Backend.SimpleLocalnet,
                      Control.Distributed.Process.Backend.SimpleLocalnet.Internal.Multicast
   Extensions:        RankNTypes,
-                     DeriveDataTypeable,
-                     CPP
+                     DeriveDataTypeable
   ghc-options:       -Wall
   HS-Source-Dirs:    src
 
 Executable TestSimpleLocalnet
   Main-Is:           TestSimpleLocalnet.hs
-  Other-Modules:
-    Control.Distributed.Process.Backend.SimpleLocalnet
-    Control.Distributed.Process.Backend.SimpleLocalnet.Internal.Multicast
-  If flag(build-example)
-    Build-Depends:     base >= 4.4 && < 5,
-                       bytestring >= 0.9 && < 0.11,
-                       network >= 2.3 && < 2.7,
-                       network-multicast >= 0.0 && < 0.3,
-                       data-accessor >= 0.2 && < 0.3,
-                       binary >= 0.5 && < 0.9,
-                       containers >= 0.4 && < 0.6,
-                       transformers >= 0.2 && < 0.6,
-                       network-transport >= 0.5 && < 0.6,
-                       network-transport-tcp >= 0.4 && < 0.7,
-                       distributed-process >= 0.5.0 && < 0.8
-  Else
-    Buildable: False
-  Extensions:        RankNTypes,
-                     DeriveDataTypeable,
-                     CPP
+  Build-Depends:     base >= 4.4 && < 5,
+                     distributed-process >= 0.5.0 && < 0.8,
+                     distributed-process-simplelocalnet
   ghc-options:       -Wall -threaded -rtsopts -with-rtsopts=-N -fno-warn-unused-do-bind 
-  HS-Source-Dirs:    tests src
+  HS-Source-Dirs:    tests

--- a/distributed-process-simplelocalnet.cabal
+++ b/distributed-process-simplelocalnet.cabal
@@ -29,15 +29,15 @@ Flag build-example
 
 Library
   Build-Depends:     base >= 4.4 && < 5,
-                     bytestring >= 0.9 && < 0.11,
-                     network >= 2.3 && < 2.7,
-                     network-multicast >= 0.1.1 && < 0.3,
+                     bytestring >= 0.9 && < 0.12,
+                     network >= 3.0 && < 3.2,
+                     network-multicast >= 0.1.1 && < 0.4,
                      data-accessor >= 0.2 && < 0.3,
                      binary >= 0.6.3 && < 0.9,
-                     containers >= 0.4 && < 0.6,
-                     transformers >= 0.2 && < 0.6,
+                     containers >= 0.4 && < 0.8,
+                     transformers >= 0.2 && < 0.7,
                      network-transport >= 0.5 && < 0.6,
-                     network-transport-tcp >= 0.4 && < 0.7,
+                     network-transport-tcp >= 0.4 && < 0.9,
                      distributed-process >= 0.5.0 && < 0.8
   Exposed-modules:   Control.Distributed.Process.Backend.SimpleLocalnet,
                      Control.Distributed.Process.Backend.SimpleLocalnet.Internal.Multicast

--- a/src/Control/Distributed/Process/Backend/SimpleLocalnet.hs
+++ b/src/Control/Distributed/Process/Backend/SimpleLocalnet.hs
@@ -147,6 +147,8 @@ import qualified Control.Distributed.Process.Node as Node
 import qualified Network.Transport.TCP as NT
   ( createTransport
   , defaultTCPParameters
+  , TCPAddr(Addressable)
+  , TCPAddrInfo(TCPAddrInfo)
   )
 import qualified Network.Transport as NT (Transport)
 import qualified Network.Socket as N (HostName, ServiceName, SockAddr)
@@ -174,7 +176,7 @@ data BackendState = BackendState {
 -- | Initialize the backend
 initializeBackend :: N.HostName -> N.ServiceName -> RemoteTable -> IO Backend
 initializeBackend host port rtable = do
-  mTransport   <- NT.createTransport host port (\sn -> (host, sn))
+  mTransport   <- NT.createTransport (NT.Addressable $ NT.TCPAddrInfo host port (\sn -> (host, sn)))
                                      NT.defaultTCPParameters
   (recv, sendp) <- initMulticast  "224.0.0.99" 9999 1024
   (_, backendState) <- fixIO $ \ ~(tid, _) -> do

--- a/src/Control/Distributed/Process/Backend/SimpleLocalnet/Internal/Multicast.hs
+++ b/src/Control/Distributed/Process/Backend/SimpleLocalnet/Internal/Multicast.hs
@@ -60,13 +60,6 @@ initMulticast host port bufferSize = do
 
 type UDPState = Map SockAddr BSL.ByteString
 
-#if MIN_VERSION_network(2,4,0)
--- network-2.4.0 provides the Ord instance for us
-#else
-instance Ord SockAddr where
-  compare = compare `on` show
-#endif
-
 bufferFor :: SockAddr -> Accessor UDPState BSL.ByteString
 bufferFor = DAC.mapDefault BSL.empty
 


### PR DESCRIPTION
Hello,

This is a simple PR which updates dependencies to support GHC 9.8.

In this process, updating the library to support `network` 3 was required. I have opted to drop support for `network` 2, which is a breaking change.